### PR TITLE
avoid nav cover btn in index header

### DIFF
--- a/src/css/general/IndexPage.styl
+++ b/src/css/general/IndexPage.styl
@@ -230,7 +230,7 @@
     }
 
     // Media Queries
-    @media only screen and (min-width: 1024px) {
+    @media only screen and (min-width: 1024px) and (min-height: 720px) {
       .title--wrapper {
         padding-top: 250px
         padding-left: 250px


### PR DESCRIPTION
目前視窗高度小於 720px 時，
`<nav>` 會蓋住 按鈕 們
![image](https://user-images.githubusercontent.com/1808835/28219474-ab7a8e60-68ee-11e7-9eae-2b97e8f31354.png)
